### PR TITLE
Support routes outside of the five primary routes

### DIFF
--- a/group.go
+++ b/group.go
@@ -86,8 +86,8 @@ func (g *group) OPTIONS(route string, hs ...common.Handler) {
 	g.r.OPTIONS(route, newHandler(hs))
 }
 
-// DELETE will set a DELETE endpoint
-func (g *group) ROUTE(method, route string, hs ...common.Handler) {
+// Handle will create a route for any method
+func (g *group) Handle(method, route string, hs ...common.Handler) {
 	if g.route != "" {
 		route = path.Join(g.route, route)
 	}
@@ -96,7 +96,7 @@ func (g *group) ROUTE(method, route string, hs ...common.Handler) {
 		hs = append(g.hs, hs...)
 	}
 
-	g.r.ROUTE(method, route, newHandler(hs))
+	g.r.Handle(method, route, newHandler(hs))
 }
 
 // Group will return a new group
@@ -119,7 +119,7 @@ type Group interface {
 	PUT(route string, hs ...common.Handler)
 	DELETE(route string, hs ...common.Handler)
 	OPTIONS(route string, hs ...common.Handler)
-	ROUTE(method, route string, hs ...common.Handler)
 
 	Group(route string, hs ...common.Handler) Group
+	Handle(method, route string, hs ...common.Handler)
 }

--- a/group.go
+++ b/group.go
@@ -86,6 +86,19 @@ func (g *group) OPTIONS(route string, hs ...common.Handler) {
 	g.r.OPTIONS(route, newHandler(hs))
 }
 
+// DELETE will set a DELETE endpoint
+func (g *group) ROUTE(method, route string, hs ...common.Handler) {
+	if g.route != "" {
+		route = path.Join(g.route, route)
+	}
+
+	if len(g.hs) > 0 {
+		hs = append(g.hs, hs...)
+	}
+
+	g.r.ROUTE(method, route, newHandler(hs))
+}
+
 // Group will return a new group
 func (g *group) Group(route string, hs ...common.Handler) Group {
 	if g.route != "" {
@@ -106,6 +119,7 @@ type Group interface {
 	PUT(route string, hs ...common.Handler)
 	DELETE(route string, hs ...common.Handler)
 	OPTIONS(route string, hs ...common.Handler)
+	ROUTE(method, route string, hs ...common.Handler)
 
 	Group(route string, hs ...common.Handler) Group
 }

--- a/router.go
+++ b/router.go
@@ -109,6 +109,11 @@ func (r *Router) OPTIONS(url string, h common.Handler) error {
 	return r.Handle("OPTIONS", url, h)
 }
 
+// ROUTE will create a route with any given method
+func (r *Router) ROUTE(method, url string, h common.Handler) error {
+	return r.Handle(method, url, h)
+}
+
 func (r *Router) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	h, params, ok := r.Match(req.Method, req.URL.Path)
 	if !ok {

--- a/router.go
+++ b/router.go
@@ -109,11 +109,6 @@ func (r *Router) OPTIONS(url string, h common.Handler) error {
 	return r.Handle("OPTIONS", url, h)
 }
 
-// ROUTE will create a route with any given method
-func (r *Router) ROUTE(method, url string, h common.Handler) error {
-	return r.Handle(method, url, h)
-}
-
 func (r *Router) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	h, params, ok := r.Match(req.Method, req.URL.Path)
 	if !ok {


### PR DESCRIPTION
```
%  go test -v
=== RUN   TestHTMLResponse
--- PASS: TestHTMLResponse (0.00s)
=== RUN   TestServeText
--- PASS: TestServeText (0.21s)
=== RUN   TestServeJSON
--- PASS: TestServeJSON (0.40s)
=== RUN   TestJSONResponseData
--- PASS: TestJSONResponseData (0.00s)
=== RUN   TestJSONResponseError
--- PASS: TestJSONResponseError (0.00s)
=== RUN   TestRouteCheck
--- PASS: TestRouteCheck (0.00s)
=== RUN   TestRouteAfterParam
--- PASS: TestRouteAfterParam (0.00s)
=== RUN   TestRouter
--- PASS: TestRouter (0.00s)
=== RUN   TestTextResponse
--- PASS: TestTextResponse (0.00s)
=== RUN   TestGetParts_small
Parts: [/hello/world :name]
--- PASS: TestGetParts_small (0.00s)
=== RUN   TestGetParts_medium
Parts: [/hello/world :name :age]
--- PASS: TestGetParts_medium (0.00s)
=== RUN   TestGetParts_large
Parts: [/hello/world :name :age :occupation]
--- PASS: TestGetParts_large (0.00s)
=== RUN   TestGetParts_param
Parts: [/api/releases/hatch :platform :environment /latest]
--- PASS: TestGetParts_param (0.00s)
PASS
ok      github.com/vroomy/httpserve     1.418s
```