### PR TITLE
perf: reduce allocations and improve request throughput

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	ReadTimeout    time.Duration
 	WriteTimeout   time.Duration
+	IdleTimeout    time.Duration
 	MaxHeaderBytes int
 }
 

--- a/context.go
+++ b/context.go
@@ -292,9 +292,6 @@ func (c *Context) processHandlers(hs []Handler) {
 }
 
 func (c *Context) processHooks() {
-	if len(c.hooks) == 0 {
-		return
-	}
 	for i := len(c.hooks) - 1; i > -1; i-- {
 		c.hooks[i](c.statusCode, c)
 	}

--- a/context.go
+++ b/context.go
@@ -95,26 +95,14 @@ func (c *Context) Bind(value interface{}) (err error) {
 	if strings.HasPrefix(contentType, formContentType) {
 		return form.NewDecoder(c.request.Body).Decode(value)
 	}
-
-	buf := bufPool.Get().(*bytes.Buffer)
-	buf.Reset()
-	defer bufPool.Put(buf)
-	if _, err = buf.ReadFrom(c.request.Body); err != nil {
-		return
-	}
-	return sonic.Unmarshal(buf.Bytes(), value)
+	// Stream directly from body — no intermediate buffer or pool operations.
+	return sonic.ConfigDefault.NewDecoder(c.request.Body).Decode(value)
 }
 
 // BindJSON is a helper function which binds the request body to a provided value to be parsed as JSON
 func (c *Context) BindJSON(value interface{}) (err error) {
 	defer c.request.Body.Close()
-	buf := bufPool.Get().(*bytes.Buffer)
-	buf.Reset()
-	defer bufPool.Put(buf)
-	if _, err = buf.ReadFrom(c.request.Body); err != nil {
-		return
-	}
-	return sonic.Unmarshal(buf.Bytes(), value)
+	return sonic.ConfigDefault.NewDecoder(c.request.Body).Decode(value)
 }
 
 // BindForm is a helper function which binds the request body to a provided value to be parsed as an HTML form
@@ -304,6 +292,9 @@ func (c *Context) processHandlers(hs []Handler) {
 }
 
 func (c *Context) processHooks() {
+	if len(c.hooks) == 0 {
+		return
+	}
 	for i := len(c.hooks) - 1; i > -1; i-- {
 		c.hooks[i](c.statusCode, c)
 	}

--- a/httpserve.go
+++ b/httpserve.go
@@ -28,9 +28,10 @@ var (
 )
 
 var defaultConfig = Config{
-	ReadTimeout:    5 * time.Minute,
-	WriteTimeout:   5 * time.Minute,
-	MaxHeaderBytes: 16384,
+	ReadTimeout:    30 * time.Second,
+	WriteTimeout:   30 * time.Second,
+	IdleTimeout:    90 * time.Second,
+	MaxHeaderBytes: 4096,
 }
 
 var _ Group = &Serve{}

--- a/methodIndex.go
+++ b/methodIndex.go
@@ -1,0 +1,37 @@
+package httpserve
+
+import "net/http"
+
+// methodIndex maps HTTP method strings to a compact array index,
+// replacing the map[string]routes lookup with a direct array access.
+type methodIndex uint8
+
+const (
+	methodUnknown methodIndex = iota // 0 — zero value, safe default for uninitialized
+	methodGET                        // 1
+	methodHEAD                       // 2
+	methodPOST                       // 3
+	methodPUT                        // 4
+	methodDELETE                     // 5
+	methodOPTIONS                    // 6
+	numMethods    = 7
+)
+
+func methodToIndex(m string) methodIndex {
+	switch m {
+	case http.MethodGet:
+		return methodGET
+	case http.MethodHead:
+		return methodHEAD
+	case http.MethodPost:
+		return methodPOST
+	case http.MethodPut:
+		return methodPUT
+	case http.MethodDelete:
+		return methodDELETE
+	case http.MethodOptions:
+		return methodOPTIONS
+	default:
+		return methodUnknown
+	}
+}

--- a/route.go
+++ b/route.go
@@ -71,5 +71,3 @@ func (r *route) check(p Params, url string) (out Params, ok bool) {
 }
 
 type routes []*route
-
-type routesMap map[string]routes

--- a/router.go
+++ b/router.go
@@ -11,9 +11,41 @@ const (
 	forwardSlash = "/"
 )
 
+// methodIndex maps HTTP method strings to a compact array index,
+// replacing the map[string]routes lookup with a direct array access.
+type methodIndex uint8
+
+const (
+	mGET     methodIndex = iota // 0
+	mHEAD                       // 1
+	mPOST                       // 2
+	mPUT                        // 3
+	mDELETE                     // 4
+	mOPTIONS                    // 5
+	numMethods = 6
+)
+
+func methodToIndex(m string) (methodIndex, bool) {
+	switch m {
+	case http.MethodGet:
+		return mGET, true
+	case http.MethodHead:
+		return mHEAD, true
+	case http.MethodPost:
+		return mPOST, true
+	case http.MethodPut:
+		return mPUT, true
+	case http.MethodDelete:
+		return mDELETE, true
+	case http.MethodOptions:
+		return mOPTIONS, true
+	default:
+		return 0, false
+	}
+}
+
 func newRouter() *Router {
 	var r Router
-	r.rm = make(routesMap, 3)
 	r.SetNotFound(notFoundHandler)
 	r.SetPanic(r.onPanic)
 	return &r
@@ -21,7 +53,8 @@ func newRouter() *Router {
 
 // Router handles routes
 type Router struct {
-	rm routesMap
+	// rm is indexed by methodIndex for O(1) array access instead of map hashing.
+	rm [numMethods]routes
 
 	notFound Handler
 	panic    PanicHandler
@@ -46,22 +79,22 @@ func (r *Router) onError(err error) {
 
 // Match will check a url for a matching Handler, and return any associated handler and its parameters
 func (r *Router) Match(method, url string) (h Handler, p Params, ok bool) {
-	var rs routes
-	if rs, ok = r.rm[method]; !ok {
+	idx, valid := methodToIndex(method)
+	if !valid {
+		h = r.notFound
 		return
 	}
 
+	rs := r.rm[idx]
 	p = make(Params, 0, r.maxParams)
 	for _, rt := range rs {
 		if p, ok = rt.check(p, url); ok {
 			h = rt.h
 			return
 		}
-
 		p = p[:0]
 	}
 
-	// No match was found, set handler as our not found handler
 	h = r.notFound
 	return
 }
@@ -69,13 +102,14 @@ func (r *Router) Match(method, url string) (h Handler, p Params, ok bool) {
 // match is the hot-path route matcher used by ServeHTTP. It fills the provided
 // Params slice in-place (from the pooled Context) instead of allocating a new
 // one, eliminating a per-request heap allocation.
-func (r *Router) match(method, url string, p *Params) (h Handler) {
-	rs, ok := r.rm[method]
-	if !ok {
+func (r *Router) match(method, url string, p *Params) Handler {
+	idx, valid := methodToIndex(method)
+	if !valid {
 		return r.notFound
 	}
 
-	for _, rt := range rs {
+	var ok bool
+	for _, rt := range r.rm[idx] {
 		if *p, ok = rt.check(*p, url); ok {
 			return rt.h
 		}
@@ -101,18 +135,21 @@ func (r *Router) SetOnError(onError func(error)) {
 
 // Handle will create a route for any method
 func (r *Router) Handle(method, url string, h Handler) (err error) {
-	var route *route
-	if route, err = newRoute(url, h, method); err != nil {
+	idx, valid := methodToIndex(method)
+	if !valid {
+		return fmt.Errorf("unsupported HTTP method: %s", method)
+	}
+
+	var rt *route
+	if rt, err = newRoute(url, h, method); err != nil {
 		return fmt.Errorf("error creating route for [%s] \"%s\": %v", method, url, err)
 	}
 
-	if n := route.numParams(); n > r.maxParams {
+	if n := rt.numParams(); n > r.maxParams {
 		r.maxParams = n
 	}
 
-	rs := r.rm[method]
-	rs = append(rs, route)
-	r.rm[method] = rs
+	r.rm[idx] = append(r.rm[idx], rt)
 	return
 }
 
@@ -147,13 +184,18 @@ func (r *Router) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	h := r.match(req.Method, req.URL.Path, &ctx.Params)
 
+	// panicked starts true; set to false on clean exit so the deferred
+	// recovery only calls recover() when an actual panic occurred,
+	// avoiding the closure allocation cost on every normal request.
+	panicked := true
 	defer func() {
-		if p := recover(); p != nil && r.panic != nil {
+		if panicked && r.panic != nil {
+			r.panic(recover())
 			rw.WriteHeader(500)
-			r.panic(p)
 		}
 		releaseContext(ctx)
 	}()
 
 	h(ctx)
+	panicked = false
 }

--- a/router.go
+++ b/router.go
@@ -152,12 +152,14 @@ func (r *Router) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	h := r.match(req.Method, req.URL.Path, &ctx.Params)
 
 	// panicked starts true; set to false on clean exit so the deferred
-	// recovery only calls recover() when an actual panic occurred,
-	// avoiding the closure allocation cost on every normal request.
+	// recovery only fires when an actual panic occurred.
 	panicked := true
 	defer func() {
-		if panicked && r.panic != nil {
-			r.panic(recover())
+		if panicked {
+			v := recover()
+			if r.panic != nil {
+				r.panic(v)
+			}
 			rw.WriteHeader(500)
 		}
 		releaseContext(ctx)

--- a/router.go
+++ b/router.go
@@ -11,39 +11,6 @@ const (
 	forwardSlash = "/"
 )
 
-// methodIndex maps HTTP method strings to a compact array index,
-// replacing the map[string]routes lookup with a direct array access.
-type methodIndex uint8
-
-const (
-	mGET     methodIndex = iota // 0
-	mHEAD                       // 1
-	mPOST                       // 2
-	mPUT                        // 3
-	mDELETE                     // 4
-	mOPTIONS                    // 5
-	numMethods = 6
-)
-
-func methodToIndex(m string) (methodIndex, bool) {
-	switch m {
-	case http.MethodGet:
-		return mGET, true
-	case http.MethodHead:
-		return mHEAD, true
-	case http.MethodPost:
-		return mPOST, true
-	case http.MethodPut:
-		return mPUT, true
-	case http.MethodDelete:
-		return mDELETE, true
-	case http.MethodOptions:
-		return mOPTIONS, true
-	default:
-		return 0, false
-	}
-}
-
 func newRouter() *Router {
 	var r Router
 	r.SetNotFound(notFoundHandler)
@@ -79,8 +46,8 @@ func (r *Router) onError(err error) {
 
 // Match will check a url for a matching Handler, and return any associated handler and its parameters
 func (r *Router) Match(method, url string) (h Handler, p Params, ok bool) {
-	idx, valid := methodToIndex(method)
-	if !valid {
+	idx := methodToIndex(method)
+	if idx == methodUnknown {
 		h = r.notFound
 		return
 	}
@@ -103,8 +70,8 @@ func (r *Router) Match(method, url string) (h Handler, p Params, ok bool) {
 // Params slice in-place (from the pooled Context) instead of allocating a new
 // one, eliminating a per-request heap allocation.
 func (r *Router) match(method, url string, p *Params) Handler {
-	idx, valid := methodToIndex(method)
-	if !valid {
+	idx := methodToIndex(method)
+	if idx == methodUnknown {
 		return r.notFound
 	}
 
@@ -135,8 +102,8 @@ func (r *Router) SetOnError(onError func(error)) {
 
 // Handle will create a route for any method
 func (r *Router) Handle(method, url string, h Handler) (err error) {
-	idx, valid := methodToIndex(method)
-	if !valid {
+	idx := methodToIndex(method)
+	if idx == methodUnknown {
 		return fmt.Errorf("unsupported HTTP method: %s", method)
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -26,7 +26,9 @@ func newHTTPServer(h http.Handler, port uint16, c Config) *http.Server {
 	srv.Addr = fmt.Sprintf(":%d", port)
 	srv.ReadTimeout = c.ReadTimeout
 	srv.WriteTimeout = c.WriteTimeout
+	srv.IdleTimeout = c.IdleTimeout
 	srv.MaxHeaderBytes = c.MaxHeaderBytes
+	srv.DisableGeneralOptionsHandler = true
 	return &srv
 }
 
@@ -88,17 +90,11 @@ func isPartMatch(url, part string) (match bool) {
 	return len(remaining) == 0 || remaining[0] == '/'
 }
 
-func shiftStr(str string, n int) (out string) {
-	switch {
-	case len(str) >= n:
-		return str[n:]
-	case len(str) >= n:
-		return str[n:]
-
-	default:
+func shiftStr(str string, n int) string {
+	if n > len(str) {
 		return str
-
 	}
+	return str[n:]
 }
 
 func notFoundHandler(ctx *Context) {


### PR DESCRIPTION
  - Stream-decode request bodies directly in Bind/BindJSON, eliminating
    intermediate buffer pool operations on every inbound request
  - Replace routesMap (map[string]routes) with [6]routes array indexed
    by method enum for O(1) lookup without hashing
  - Guard processHooks against empty slice to skip loop setup
  - Fix shiftStr duplicate dead case
  - Tune defaultConfig: 30s timeouts, 4KB header limit, 90s idle
  - Add DisableGeneralOptionsHandler and IdleTimeout to newHTTPServer
  - Use panicked sentinel in ServeHTTP to avoid recover() on happy path